### PR TITLE
Fix type definition in gatsby-plugin-google-analytics

### DIFF
--- a/packages/gatsby-plugin-google-analytics/index.d.ts
+++ b/packages/gatsby-plugin-google-analytics/index.d.ts
@@ -14,10 +14,10 @@ export interface CustomEventArgs {
   action: string
   label?: string
   value?: string
-  nonInteraction: boolean
-  transport: "beacon" | "xhr" | "image"
-  hitCallback: Function
-  callbackTimeout: Number
+  nonInteraction?: boolean
+  transport?: "beacon" | "xhr" | "image"
+  hitCallback?: Function
+  callbackTimeout?: Number
 }
 
 export function trackCustomEvent(args: CustomEventArgs): void


### PR DESCRIPTION
## Description

When we send events to GA, only `category` and `action` properties are required. This small PR makes all other properties in `CustomEventArgs` type optional.